### PR TITLE
Remove paypal plugin dependency (#220)

### DIFF
--- a/Tests/Form/ChoosePaymentMethodTypeTest.php
+++ b/Tests/Form/ChoosePaymentMethodTypeTest.php
@@ -3,8 +3,8 @@
 namespace JMS\Payment\CoreBundle\Tests\Form\ChoosePaymentMethodTypeTest;
 
 use JMS\Payment\CoreBundle\Form\ChoosePaymentMethodType;
+use JMS\Payment\CoreBundle\Tests\Functional\TestPlugin\Form\TestPluginType;
 use JMS\Payment\CoreBundle\Util\Legacy;
-use JMS\Payment\PaypalBundle\Form\ExpressCheckoutType;
 use Symfony\Component\Form\PreloadedExtension;
 use Symfony\Component\Form\Test\TypeTestCase;
 use Symfony\Component\HttpKernel\Kernel;
@@ -50,7 +50,7 @@ class ChoosePaymentMethodTypeTest extends TypeTestCase
             $config = $form->get('data_'.$method)->getConfig();
 
             $this->assertInstanceOf(
-                'JMS\Payment\PaypalBundle\Form\ExpressCheckoutType',
+                'JMS\Payment\CoreBundle\Tests\Functional\TestPlugin\Form\TestPluginType',
                 $config->getType()->getInnerType()
             );
         }
@@ -194,7 +194,7 @@ class ChoosePaymentMethodTypeTest extends TypeTestCase
 
     protected function getExtensions()
     {
-        $pluginType = new ExpressCheckoutType();
+        $pluginType = new TestPluginType();
 
         if (Legacy::supportsFormTypeClass()) {
             $pluginTypeName = get_class($pluginType);

--- a/Tests/Functional/AppKernel.php
+++ b/Tests/Functional/AppKernel.php
@@ -2,6 +2,7 @@
 
 namespace JMS\Payment\CoreBundle\Tests\Functional;
 
+use JMS\Payment\CoreBundle\Tests\Functional\TestPlugin\TestPluginBundle;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\HttpKernel\Kernel;
@@ -34,7 +35,7 @@ class AppKernel extends Kernel
             new \Symfony\Bundle\TwigBundle\TwigBundle(),
             new \JMS\Payment\CoreBundle\Tests\Functional\TestBundle\TestBundle(),
             new \JMS\Payment\CoreBundle\JMSPaymentCoreBundle(),
-            new \JMS\Payment\PaypalBundle\JMSPaymentPaypalBundle(),
+            new TestPluginBundle(),
             new \Sensio\Bundle\FrameworkExtraBundle\SensioFrameworkExtraBundle(),
         );
     }
@@ -46,6 +47,11 @@ class AppKernel extends Kernel
 
     public function getCacheDir()
     {
-        return sys_get_temp_dir().'/JMSPaymentCoreBundle';
+        return sys_get_temp_dir().'/JMSPaymentCoreBundle/cache';
+    }
+
+    public function getLogDir()
+    {
+        return sys_get_temp_dir().'/JMSPaymentCoreBundle/logs';
     }
 }

--- a/Tests/Functional/BasePaymentWorkflowTest.php
+++ b/Tests/Functional/BasePaymentWorkflowTest.php
@@ -35,7 +35,7 @@ abstract class BasePaymentWorkflowTest extends BaseTestCase
 
         $crawler = $client->request('GET', $router->generate('payment_details', array('id' => $order->getId())));
         $form = $crawler->selectButton('submit_btn')->form();
-        $form['jms_choose_payment_method[method]']->select('paypal_express_checkout');
+        $form['jms_choose_payment_method[method]']->select('test_plugin');
         $client->submit($form);
 
         $response = $client->getResponse();

--- a/Tests/Functional/BasicEntityInteractionsTest.php
+++ b/Tests/Functional/BasicEntityInteractionsTest.php
@@ -17,7 +17,7 @@ class BasicEntityInteractionsTest extends BaseTestCase
         $c = self::$kernel->getContainer();
         $ppc = $c->get('payment.plugin_controller');
         $em = $c->get('doctrine.orm.entity_manager');
-        $instruction = new PaymentInstruction(123.45, 'EUR', 'paypal_express_checkout');
+        $instruction = new PaymentInstruction(123.45, 'EUR', 'test_plugin');
         $ppc->createPaymentInstruction($instruction);
         $credit = $ppc->createIndependentCredit($instruction->getId(), 123);
 

--- a/Tests/Functional/TestBundle/Controller/OrderController.php
+++ b/Tests/Functional/TestBundle/Controller/OrderController.php
@@ -33,7 +33,7 @@ class OrderController extends Controller
             'currency' => 'EUR',
             'amount' => $order->getAmount(),
             'predefined_data' => array(
-                'paypal_express_checkout' => array(
+                'test_plugin' => array(
                     'foo' => 'bar',
                 ),
             ),

--- a/Tests/Functional/TestBundle/Resources/config/default.yml
+++ b/Tests/Functional/TestBundle/Resources/config/default.yml
@@ -11,10 +11,3 @@ doctrine:
 
 services:
     em: "@doctrine.orm.entity_manager"
-
-jms_payment_paypal:
-    username: schmit_1283340315_biz_api1.gmail.com
-    password: 1283340321
-    signature: A93vj6VJ.ZIRNjbI6GFgi4N2Km.5ATLs-EinlyWk2htEGX0xc3L8YIBo
-    return_url: http://paypal.test/payment
-    cancel_url: http://paypal.test/payment

--- a/Tests/Functional/TestPlugin/DependencyInjection/TestPluginExtension.php
+++ b/Tests/Functional/TestPlugin/DependencyInjection/TestPluginExtension.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace JMS\Payment\CoreBundle\Tests\Functional\TestPlugin\DependencyInjection;
+
+use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Extension\Extension;
+use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
+
+class TestPluginExtension extends Extension
+{
+    public function load(array $configs, ContainerBuilder $container)
+    {
+        $loader = new YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
+        $loader->load('services.yml');
+    }
+}

--- a/Tests/Functional/TestPlugin/Form/TestPluginType.php
+++ b/Tests/Functional/TestPlugin/Form/TestPluginType.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace JMS\Payment\CoreBundle\Tests\Functional\TestPlugin\Form;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilderInterface;
+
+class TestPluginType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+    }
+    public function getName()
+    {
+        return 'test_plugin';
+    }
+}

--- a/Tests/Functional/TestPlugin/Plugin/TestPlugin.php
+++ b/Tests/Functional/TestPlugin/Plugin/TestPlugin.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace JMS\Payment\CoreBundle\Tests\Functional\TestPlugin\Plugin;
+
+use JMS\Payment\CoreBundle\Plugin\AbstractPlugin;
+
+class TestPlugin extends AbstractPlugin
+{
+    public function processes($paymentSystemName)
+    {
+        return 'test_plugin' === $paymentSystemName;
+    }
+}

--- a/Tests/Functional/TestPlugin/Resources/config/services.yml
+++ b/Tests/Functional/TestPlugin/Resources/config/services.yml
@@ -1,0 +1,11 @@
+services:
+    test_plugin:
+        class: JMS\Payment\CoreBundle\Tests\Functional\TestPlugin\Plugin\TestPlugin
+        tags:
+            - { name: payment.plugin }
+
+    test_plugin_type:
+        class: JMS\Payment\CoreBundle\Tests\Functional\TestPlugin\Form\TestPluginType
+        tags:
+            - { name: payment.method_form_type }
+            - { name: form.type, alias: test_plugin }

--- a/Tests/Functional/TestPlugin/TestPluginBundle.php
+++ b/Tests/Functional/TestPlugin/TestPluginBundle.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace JMS\Payment\CoreBundle\Tests\Functional\TestPlugin;
+
+use Symfony\Component\HttpKernel\Bundle\Bundle;
+
+class TestPluginBundle extends Bundle
+{
+}

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,6 @@
         "phpunit/phpunit": "~4.8|~5.4",
         "symfony/phpunit-bridge": "~2.7",
         "doctrine/doctrine-bundle": "~1.6",
-        "jms/payment-paypal-bundle": "~1.0",
         "sensio/framework-extra-bundle": "~3.0",
         "symfony/dom-crawler": "~2.3|~3.0",
         "symfony/doctrine-bridge": "~2.3|~3.0",


### PR DESCRIPTION
* Cache and test dirs for tests should be in tmp directory

* Add a TestPlugin to use instead of the paypal plugin

* Remove all references to paypal plugin in favor of the test plugin